### PR TITLE
Fix typo in mapTextSL

### DIFF
--- a/R/utility.R
+++ b/R/utility.R
@@ -275,7 +275,7 @@ get_coord<- function(string){ # extracts text coordinates from trial info
 }
 
 
-mapTextSL<- function(sent, ppl= 11, xOffset= 50, ResY= 1080){
+mapTextSL<- function(string, ppl= 11, xOffset= 50, ResY= 1080){
   
   ###
   char<- 0:(nchar(string)-1)


### PR DESCRIPTION
Just noticed an error with this function -- the input parameter should be called string, not sent